### PR TITLE
Removed allow backup attribute on manifest

### DIFF
--- a/animator/src/main/AndroidManifest.xml
+++ b/animator/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="io.codetail.animation">
 
-    <application android:allowBackup="true">
+    <application>
 
     </application>
 


### PR DESCRIPTION
This was forcing lib users to include tools:replace="android:allowBackup" if they need to disable the back up on their apps.
